### PR TITLE
When the API rate per minute has been exceeded, this modal should should show up asking users to wait for two minutes then reload the page

### DIFF
--- a/culinary-canvas/capstone-project/frontend/my_capstone_project/src/RateLimitModal.css
+++ b/culinary-canvas/capstone-project/frontend/my_capstone_project/src/RateLimitModal.css
@@ -1,0 +1,33 @@
+.modal-overlay{
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content{
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    text-align: center;
+}
+
+button.close{
+    margin-top: 20px;
+    padding: 10px 20px;
+    border: none;
+    background: #007bff;
+    color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+button:hover{
+    background: #0056b3;
+}

--- a/culinary-canvas/capstone-project/frontend/my_capstone_project/src/RateLimitModal.jsx
+++ b/culinary-canvas/capstone-project/frontend/my_capstone_project/src/RateLimitModal.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import './RateLimitModal.css';
+
+function RateLimitModal({isOpen, onClose}){
+    if(!isOpen){
+        return null;
+    }
+    return(
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <h2>Rate Limit Exceeded</h2>
+                <p>You have reached the maximum number of API calls per minute. Please wait for 2 minutes and reload the page.</p>
+                <button className="close" onClick={onClose}>Close</button>
+            </div>
+        </div>
+    )
+}
+export default RateLimitModal;


### PR DESCRIPTION
This modal makes the user experience better because when the API calls per minute has been exceeded no recipes are going to be displayed.
<img width="560" alt="Screenshot 2024-07-17 at 12 04 23 PM" src="https://github.com/user-attachments/assets/19b53d63-3358-4df3-b933-3932a0753024">
